### PR TITLE
Make the position of the filter icon customizable with respect to the existing icon for the column label.

### DIFF
--- a/swingbits/src/main/java/org/oxbow/swingbits/table/filter/TableRowFilterSupport.java
+++ b/swingbits/src/main/java/org/oxbow/swingbits/table/filter/TableRowFilterSupport.java
@@ -37,6 +37,7 @@ import java.beans.PropertyChangeListener;
 import java.util.Collections;
 
 import javax.swing.JTable;
+import javax.swing.SwingConstants;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableModel;
 
@@ -51,6 +52,7 @@ public final class TableRowFilterSupport {
     private IObjectToStringTranslator translator;
     private final ITableFilter<?> filter;
     private boolean actionsVisible = true;
+    private int filterIconPlacement = SwingConstants.LEADING;
     private boolean useTableRenderers = false;
 
     private TableRowFilterSupport( ITableFilter<?> filter ) {
@@ -74,6 +76,25 @@ public final class TableRowFilterSupport {
      */
     public TableRowFilterSupport actions( boolean visible ) {
         this.actionsVisible = visible;
+        return this;
+    }
+
+    /**
+     * Set the placement of the filter icon with respect to the existing icon
+     * in the column label.
+     *
+     * @param filterIconPlacement either SwingConstants.LEADING or
+     *         SwingConstants.TRAILING.
+     * @return this
+     */
+    public TableRowFilterSupport filterIconPlacement(int filterIconPlacement) {
+        if (filterIconPlacement != SwingConstants.LEADING &&
+                filterIconPlacement != SwingConstants.TRAILING) {
+            throw new UnsupportedOperationException("The filter icon " +         
+                    "placement can only take the values of " +                   
+                    "SwingConstants.LEADING or SwingConstants.TRAILING");
+        }
+        this.filterIconPlacement = filterIconPlacement;
         return this;
     }
 
@@ -151,7 +172,8 @@ public final class TableRowFilterSupport {
 
         JTable table =  filter.getTable();
 
-        FilterTableHeaderRenderer headerRenderer = new FilterTableHeaderRenderer(filter);
+        FilterTableHeaderRenderer headerRenderer =
+                new FilterTableHeaderRenderer(filter, filterIconPlacement);
         filter.modelChanged( newModel );
 
         for( TableColumn c:  Collections.list( table.getColumnModel().getColumns()) ) {


### PR DESCRIPTION
Currently, when a filter icon appears it forces the existing icon to appear on the leading edge of the text. This is not desired in cases where one would prefer that the icon stays on the trailing edge of the text (e.g. the behavior of the JXTable header renderer). This change makes it so that the filter icon's placement relative to the existing icon is customizable, but it does not cause the existing icon to switch to the other side of the label.
