### PR TITLE
fix possible NPE

### DIFF
--- a/swingbits/src/main/java/org/oxbow/swingbits/dialog/task/TaskDialog.java
+++ b/swingbits/src/main/java/org/oxbow/swingbits/dialog/task/TaskDialog.java
@@ -801,7 +801,7 @@ public class TaskDialog extends SwingBean {
      * @return
      */
     public String getString( String text ) {
-        return text.startsWith(I18N_PREFIX)? getLocalizedString(text.substring(I18N_PREFIX.length())) : text;
+        return text != null && text.startsWith(I18N_PREFIX)? getLocalizedString(text.substring(I18N_PREFIX.length())) : text;
     }
 
     


### PR DESCRIPTION
If you call TaskDialogs.build(...).message(); without .title(...) the NPE was thrown.