### PR TITLE
Buttons of Choice-TaskDialog don't take up available space

### DIFF
--- a/swingbits/src/main/java/org/oxbow/swingbits/dialog/task/TaskDialogs.java
+++ b/swingbits/src/main/java/org/oxbow/swingbits/dialog/task/TaskDialogs.java
@@ -381,16 +381,16 @@ public final class TaskDialogs {
             final List<CommandLinkButton> buttons = new ArrayList<CommandLinkButton>();
 
             CommandLinkButton btn;
-			final JPanel p = new JPanel(new MigLayout(new LC().flowY().noGrid()));
-			p.setOpaque(false);
-			for (final CommandLink link : choices)
-			{
-				btn = new CommandLinkButton(link, TaskDialog.getDesign().getCommandLinkPainter());
-				models.add(btn.getModel());
-				buttons.add(btn);
-				bGroup.add(btn);
-				p.add(btn, new CC().growX().gapBottom("8"));
-			}
+            final JPanel p = new JPanel(new MigLayout(new LC().flowY().noGrid().fillX()));
+            p.setOpaque(false);
+            for (final CommandLink link : choices)
+            {
+                btn = new CommandLinkButton(link, TaskDialog.getDesign().getCommandLinkPainter());
+                models.add(btn.getModel());
+                buttons.add(btn);
+                bGroup.add(btn);
+                p.add(btn, new CC().growX().gapBottom("8"));
+            }
 
             if ( defaultChoice >= 0 && defaultChoice < choices.size()) {
                 bGroup.setSelected(models.get(defaultChoice), true);


### PR DESCRIPTION
Back when I did the PRs https://github.com/eugener/oxbow/pull/53 and https://github.com/eugener/oxbow/pull/54 , I only thought I had fixed the horizontal growing issue, but since the instruction of the dialog was as long as one of the buttontexts during testing, I probably didn't notice that the actual container that contains the buttons doesn't grow horizontally. This PR will now fix this, I have tested it with miglayout versions 5.0 and 5.2.

And I have fixed the weird indentation of my previous PRs.