### PR TITLE
Fix german translation

### DIFF
--- a/swingbits/src/main/resources/task-dialog_de_DE.properties
+++ b/swingbits/src/main/resources/task-dialog_de_DE.properties
@@ -1,7 +1,7 @@
 OK=OK
 Apply=Anwenden
 Cancel=Abbrechen
-Close=Schlie√üen
+Close=Schlieﬂen
 Yes=Ja
 No=Nein
 MoreDetails=Weitere Details
@@ -13,6 +13,6 @@ Question=Frage
 Warning=Warnung
 Exception=Ausnahme
 Choice=Auswahl
-Select=Ausw√§hlen
+Select=Ausw‰hlen
 Input=Eingabe
-Clear_ALL_COLUMN_FILTERS=Filter in allen Spalten zur√ºcksetzen
+Clear_ALL_COLUMN_FILTERS=Filter in allen Spalten zur¸cksetzen


### PR DESCRIPTION
Fix german translation file, the encoding was done with UTF-8 instead of ISO 8859-1, causing incorrectly displayed characters during runtime, since the Java Properties API doesn't handle UTF-8.