### PR TITLE
New api to enable auto clean all column filters if table model row count is 0

### DIFF
--- a/swingbits/src/main/java/org/oxbow/swingbits/table/filter/AbstractTableFilter.java
+++ b/swingbits/src/main/java/org/oxbow/swingbits/table/filter/AbstractTableFilter.java
@@ -59,6 +59,8 @@ public abstract class AbstractTableFilter<T extends JTable> implements ITableFil
 
     private final T table;
     private final TableFilterState filterState = new TableFilterState();
+    
+    private boolean autoclean;
 
     public AbstractTableFilter( T table ) {
         this.table = table;
@@ -88,6 +90,11 @@ public abstract class AbstractTableFilter<T extends JTable> implements ITableFil
                 @Override
                 public void tableChanged(TableModelEvent e) {
                     clearDistinctItemCache();
+                    
+                    if (autoclean && table.getModel().getRowCount() == 0) {
+                    	clear();
+                    }
+                    
                 }
             });
         }
@@ -168,6 +175,11 @@ public abstract class AbstractTableFilter<T extends JTable> implements ITableFil
 
     public void setFilterState(int column, Collection<DistinctColumnItem> values ) {
         filterState.setValues(column, values);
+    }
+    
+    @Override
+    public void setAutoClean(boolean autoclean) {
+    	this.autoclean = autoclean;
     }
 
     public void clear() {

--- a/swingbits/src/main/java/org/oxbow/swingbits/table/filter/AbstractTableFilter.java
+++ b/swingbits/src/main/java/org/oxbow/swingbits/table/filter/AbstractTableFilter.java
@@ -59,7 +59,6 @@ public abstract class AbstractTableFilter<T extends JTable> implements ITableFil
 
     private final T table;
     private final TableFilterState filterState = new TableFilterState();
-    
     private boolean autoclean;
 
     public AbstractTableFilter( T table ) {
@@ -90,11 +89,9 @@ public abstract class AbstractTableFilter<T extends JTable> implements ITableFil
                 @Override
                 public void tableChanged(TableModelEvent e) {
                     clearDistinctItemCache();
-                    
                     if (autoclean && table.getModel().getRowCount() == 0) {
-                    	clear();
+                        clear();
                     }
-                    
                 }
             });
         }
@@ -179,7 +176,7 @@ public abstract class AbstractTableFilter<T extends JTable> implements ITableFil
     
     @Override
     public void setAutoClean(boolean autoclean) {
-    	this.autoclean = autoclean;
+        this.autoclean = autoclean;
     }
 
     public void clear() {

--- a/swingbits/src/main/java/org/oxbow/swingbits/table/filter/ITableFilter.java
+++ b/swingbits/src/main/java/org/oxbow/swingbits/table/filter/ITableFilter.java
@@ -86,6 +86,12 @@ public interface ITableFilter<T extends JTable> extends Serializable {
     void removeChangeListener( IFilterChangeListener listener );
 
     /**
+     * Set flag to clear all columns filter if model row count is 0 
+     * @param autoclean
+     */
+    void setAutoClean(boolean autoclean);
+    
+    /**
      * Clear the filter
      */
     void clear();

--- a/swingbits/src/main/java/org/oxbow/swingbits/table/filter/TableRowFilterSupport.java
+++ b/swingbits/src/main/java/org/oxbow/swingbits/table/filter/TableRowFilterSupport.java
@@ -56,6 +56,7 @@ public final class TableRowFilterSupport {
     private boolean actionsVisible = true;
     private int filterIconPlacement = SwingConstants.LEADING;
     private boolean useTableRenderers = false;
+    private boolean autoclean = false;
 
     private TableRowFilterSupport( ITableFilter<?> filter ) {
         if ( filter == null ) throw new NullPointerException();
@@ -109,6 +110,16 @@ public final class TableRowFilterSupport {
         this.searchable = searchable;
         return this;
     }
+    
+    /**
+     * Set flag to clear all filters automatically if model row count is 0
+     * @param autoclean
+     * @return
+     */
+    public TableRowFilterSupport autoclean( boolean autoclean ) {
+    	this.autoclean = autoclean;
+    	return this;
+    }
 
     public TableRowFilterSupport searchFilter(IListFilter searchFilter) {
         this.searchFilter = searchFilter;
@@ -141,7 +152,9 @@ public final class TableRowFilterSupport {
         filterPopup.setUseTableRenderers( useTableRenderers );
 
         setupTableHeader();
-
+        
+        filter.setAutoClean(autoclean);
+        
         return filter.getTable();
     }
 

--- a/swingbits/src/main/java/org/oxbow/swingbits/table/filter/TableRowFilterSupport.java
+++ b/swingbits/src/main/java/org/oxbow/swingbits/table/filter/TableRowFilterSupport.java
@@ -117,8 +117,8 @@ public final class TableRowFilterSupport {
      * @return
      */
     public TableRowFilterSupport autoclean( boolean autoclean ) {
-    	this.autoclean = autoclean;
-    	return this;
+        this.autoclean = autoclean;
+        return this;
     }
 
     public TableRowFilterSupport searchFilter(IListFilter searchFilter) {

--- a/swingbits/src/test/java/org/oxbow/swingbits/table/filter/TableFilterTest.java
+++ b/swingbits/src/test/java/org/oxbow/swingbits/table/filter/TableFilterTest.java
@@ -91,8 +91,8 @@ public class TableFilterTest implements Runnable {
 
             @Override
             public void actionPerformed(ActionEvent e) {
-            	DefaultTableModel modelo = (DefaultTableModel) table.getModel();
-            	modelo.setRowCount(0);
+                DefaultTableModel modelo = (DefaultTableModel) table.getModel();
+                modelo.setRowCount(0);
             }
         });
 
@@ -106,7 +106,7 @@ public class TableFilterTest implements Runnable {
     private TableRowFilterSupport filter;
 
     private JTable buildTable() {
-    	 
+
         filter = TableRowFilterSupport.forTable(new JTable(new DefaultTableModel(data, colNames)))
                                              .onFilterChange(new IFilterChangeListener() {
                                                  @Override

--- a/swingbits/src/test/java/org/oxbow/swingbits/table/filter/TableFilterTest.java
+++ b/swingbits/src/test/java/org/oxbow/swingbits/table/filter/TableFilterTest.java
@@ -87,6 +87,15 @@ public class TableFilterTest implements Runnable {
             }
         });
 
+        toolbar.add( new AbstractAction("Clear Table") {
+
+            @Override
+            public void actionPerformed(ActionEvent e) {
+            	DefaultTableModel modelo = (DefaultTableModel) table.getModel();
+            	modelo.setRowCount(0);
+            }
+        });
+
         
         f.pack();
         f.setLocationRelativeTo(null);
@@ -97,7 +106,8 @@ public class TableFilterTest implements Runnable {
     private TableRowFilterSupport filter;
 
     private JTable buildTable() {
-        filter = TableRowFilterSupport.forTable(new JTable())
+    	 
+        filter = TableRowFilterSupport.forTable(new JTable(new DefaultTableModel(data, colNames)))
                                              .onFilterChange(new IFilterChangeListener() {
                                                  @Override
                                                  public void filterChanged(ITableFilter<?> filter) {
@@ -106,9 +116,11 @@ public class TableFilterTest implements Runnable {
                                              })
                                             .actions(true)
                                             .searchable(true)
-                                            .useTableRenderers(true);
+                                            .useTableRenderers(true)
+                                            .autoclean(true);
+                                           
         JTable table = filter.apply();
-                table.setModel( new DefaultTableModel(data, colNames) );
+                 
         table.getColumnModel().getColumn(0).setCellRenderer(new TestRenderer());
         return table;
     }


### PR DESCRIPTION
Sometimes it is required to clean the data of the table to reload it, if there are active column filters it is necessary to clean them so that it does not interfere with the new load, for this reason I added a new functionality to activate a self-cleaning if the table is cleaned.

Currently when cleaning the table the view is as follows:

![image](https://user-images.githubusercontent.com/8385910/106794770-0b606300-6638-11eb-8da0-6ec533c20530.png)

When activating the `autoclean`, the filters disappear when cleaning the table.

Example:

```java
JTable table = TableRowFilterSupport
                  .forTable(new JTable())
                  .autoclean(true)
                  .apply();
```